### PR TITLE
Automatic migration disabled for production

### DIFF
--- a/PortfolioWeb/Program.cs
+++ b/PortfolioWeb/Program.cs
@@ -18,9 +18,9 @@ if (!app.Environment.IsDevelopment()) {
     app.UseExceptionHandler("/Home/Error");
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
+} else {
+    app.ApplyMigrations();
 }
-
-app.ApplyMigrations();
 
 app.UseHttpsRedirection();
 app.UseStaticFiles();


### PR DESCRIPTION
According to current situation database migrations won't be applied for production database. The changes will be pushed through SQL scripts right before merging. Refer to [this link](https://learn.microsoft.com/en-us/ef/core/managing-schemas/migrations/applying?tabs=dotnet-core-cli) for more details.